### PR TITLE
changing version for slaveapi to 1.6.2 and upgrade bzrest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "MarkupSafe>=0.18",
         "WebOb>=1.2.3",
         "requests>=1.2.3",
-        "bzrest==0.7",
+        "bzrest==0.9",
         "dnspython>=1.11.0",
         "paramiko>=1.11.0",
         "flask==0.10.1",

--- a/slaveapi/__init__.py
+++ b/slaveapi/__init__.py
@@ -1,2 +1,2 @@
-__version_info__ = ("1", "6", "1")
+__version_info__ = ("1", "6", "2")
 __version__ = ".".join(__version_info__)


### PR DESCRIPTION
Bug 1126879 - slaveapi fails at filing tracking bugs when it wants to file an unreachable bug for a slave without a problem tracking bug
